### PR TITLE
Fix line count for BSD/macOS wc.

### DIFF
--- a/gitcloc.sh
+++ b/gitcloc.sh
@@ -28,7 +28,7 @@ else
     git branch --merged | sed 's/^ *//; s/ *$//; /^$/d; /^[*]/d' > "$TMP_BRANCHES_FILE"
 
     # Check that there are merged branches to be delete before continueing.
-    LINE_COUNT=$(wc -l "$TMP_BRANCHES_FILE" | sed 's/ .*//')
+    LINE_COUNT=$(wc -l "$TMP_BRANCHES_FILE" | awk '{print $1}')
     if [[ $LINE_COUNT -gt 0 ]]; then
         $(git var GIT_EDITOR) "$TMP_BRANCHES_FILE"
         # Trim trailing/leading space, and empty lines after edit.


### PR DESCRIPTION
Fix script for BSD/macOS that has different formatting for the output of the `wc` command.